### PR TITLE
Add guzman and 2 motostrelecka divisions

### DIFF
--- a/frontend/src/data/divisions.json
+++ b/frontend/src/data/divisions.json
@@ -304,5 +304,17 @@
     "alliance": "ECoalition/Allied",
     "country": "CZE",
     "id": 318
+  },
+  {
+    "name": "Guzman el Bueno",
+    "alliance": "ECoalition/Allied",
+    "country": "ESP",
+    "id": 407
+  },
+  {
+    "name": "2. Motostrelecka Divize",
+    "alliance": "ECoalition/Axis",
+    "country": "CZE",
+    "id": 408
   }
 ]


### PR DESCRIPTION
Added Guzman el Bueno and 2. Motostrelecka Divize to divisions.json

Extracted id using https://github.com/izohek/warno-deck-utils