### PR TITLE
refactor: improve rank bucket ranges for win-rate analysis

### DIFF
--- a/frontend/src/stats.ts
+++ b/frontend/src/stats.ts
@@ -164,7 +164,9 @@ const calculateEnemyRankBuckets = (
 
   const getBucket = (rank: number): string | null => {
     if (rank === 0) return null;
-    if (rank <= 50) return '1-50';
+    if (rank <= 10) return '1-10';
+    if (rank <= 25) return '10-25';
+    if (rank <= 50) return '25-50';
     if (rank <= 100) return '51-100';
     if (rank <= 150) return '101-150';
     if (rank <= 200) return '151-200';

--- a/frontend/src/stats.ts
+++ b/frontend/src/stats.ts
@@ -165,8 +165,8 @@ const calculateEnemyRankBuckets = (
   const getBucket = (rank: number): string | null => {
     if (rank === 0) return null;
     if (rank <= 10) return '1-10';
-    if (rank <= 25) return '10-25';
-    if (rank <= 50) return '25-50';
+    if (rank <= 25) return '11-25';
+    if (rank <= 50) return '26-50';
     if (rank <= 100) return '51-100';
     if (rank <= 150) return '101-150';
     if (rank <= 200) return '151-200';


### PR DESCRIPTION
create more granular ladder top rank buckets for 1-10, 10-25 and 25-50 to better reflect skill distribution.

The current 1-50 bucket is too broad, as the skill gap between the top 10, top 25, and top 50 players is significant.